### PR TITLE
fix: remove composer post-install hooks (only run for root project)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,5 @@
         "psr-4": {
             "PhpGui\\": "src/"
         }
-    },
-    "scripts": {
-        "post-install-cmd": "@php scripts/install-webview-helper.php",
-        "post-update-cmd": "@php scripts/install-webview-helper.php",
-        "install-webview": "@php scripts/install-webview-helper.php"
     }
 }


### PR DESCRIPTION
Composer does not execute library scripts when installed as a dependency. The auto-download in ProcessWebView::findBinary() handles this correctly at runtime — it triggers the installer on first WebView creation.